### PR TITLE
Add /gisce_meme command

### DIFF
--- a/meldebot/bot.py
+++ b/meldebot/bot.py
@@ -18,10 +18,11 @@ from meldebot.mel.text import TEXT_HANDLERS
 from meldebot.mel.gif import GIF_HANDLERS
 from meldebot.mel.reply import REPLY_HANDLERS
 from meldebot.mel.poll import POLL_HANDLERS
+from meldebot.mel.meme import MEME_HANDLERS
 
 # Command handlers
 MEL_HANDLERS = (
-    [flute_handler] + TEXT_HANDLERS + GIF_HANDLERS + REPLY_HANDLERS + POLL_HANDLERS
+    [flute_handler] + TEXT_HANDLERS + GIF_HANDLERS + REPLY_HANDLERS + POLL_HANDLERS + MEME_HANDLERS
 )
 
 

--- a/meldebot/mel/conf.py
+++ b/meldebot/mel/conf.py
@@ -115,6 +115,13 @@ def get_tenor_api_key():
     return config.defaults().get("tenor_api_key", False)
 
 
+def get_image_server_auth():
+    return {
+        'user': config.defaults().get("image_server_user", False),
+        'password': config.defaults().get("image_server_password", False)
+    }
+
+
 def get_store_path():
     return config.defaults().get("store_path", False)
 

--- a/meldebot/mel/meme.py
+++ b/meldebot/mel/meme.py
@@ -1,0 +1,62 @@
+###############################################################################
+# Project: Mort de Gana Bot
+# Author: Ytturi
+# Descr: Answer command with custom GIF options from Giphy
+# Commands:
+# - MEL: Send random GIF (See `get_mel_params`). Usage: `/mel`
+# - MOTO: Send motorbike GIF. Usage: `/moto`
+###############################################################################
+from telegram.ext import CommandHandler
+from logging import getLogger
+from requests import get as http_get
+from requests.auth import HTTPBasicAuth
+
+# Self imports
+from meldebot.mel.conf import get_image_server_auth
+from meldebot.mel.utils import send_typing_action, remove_command_message
+
+logger = getLogger(__name__)
+
+
+def get_gisce_meme_url(params):
+    auth_info = get_image_server_auth()
+    if not auth_info:
+        logger.critical("NO AUTH INFO FOR ImageServer!")
+        exit(-1)
+
+    auth = HTTPBasicAuth(auth_info['user'], auth_info['password'])
+
+    base_url = "https://bcclean.tk/ImageServer/api"
+    if params.get("id"):
+        base_url += "/image/{}".format(params.get("id"))
+    elif params.get("tags"):
+        base_url += "/random_image/{0}".format(params.get("tags"))
+    else:
+        base_url += "/random_image"
+
+    logger.debug("ImageServer - GET: {}".format(base_url))
+    r = http_get(base_url, auth=auth)
+    if r.status_code != 200:
+        logger.error("Could not get tenor content!")
+        logger.error("{} - {}".format(r.status_code, r.text))
+        r.raise_for_status()
+    img_url = r.json()["url"]
+    return img_url
+
+
+def get_gisce_meme(**kwargs):
+    return get_gisce_meme_url(kwargs)
+
+
+# Def Handler
+@send_typing_action
+@remove_command_message
+def cb_gisce_meme_handler(update, context):
+    logger.info("Handling meme")
+    update.message.reply_photo(get_gisce_meme(id=None, tags=None), quote=False)
+
+
+gisce_meme_handler = CommandHandler("gisce_meme", cb_gisce_meme_handler)
+
+MEME_HANDLERS = [gisce_meme_handler]
+

--- a/meldebot/mel/meme.py
+++ b/meldebot/mel/meme.py
@@ -1,10 +1,9 @@
 ###############################################################################
 # Project: Mort de Gana Bot
-# Author: Ytturi
-# Descr: Answer command with custom GIF options from Giphy
+# Author: Bcedu
+# Descr: Answer command with ImageServer images
 # Commands:
-# - MEL: Send random GIF (See `get_mel_params`). Usage: `/mel`
-# - MOTO: Send motorbike GIF. Usage: `/moto`
+#  - GISCEMEME: Send random gisce meme. Usage: `/gisce_meme`
 ###############################################################################
 from telegram.ext import CommandHandler
 from logging import getLogger
@@ -18,7 +17,7 @@ from meldebot.mel.utils import send_typing_action, remove_command_message
 logger = getLogger(__name__)
 
 
-def get_gisce_meme_url(params):
+def get_gisce_meme_url(**params):
     auth_info = get_image_server_auth()
     if not auth_info:
         logger.critical("NO AUTH INFO FOR ImageServer!")
@@ -37,15 +36,11 @@ def get_gisce_meme_url(params):
     logger.debug("ImageServer - GET: {}".format(base_url))
     r = http_get(base_url, auth=auth)
     if r.status_code != 200:
-        logger.error("Could not get tenor content!")
+        logger.error("Could not get ImageServer content!")
         logger.error("{} - {}".format(r.status_code, r.text))
         r.raise_for_status()
     img_url = r.json()["url"]
     return img_url
-
-
-def get_gisce_meme(**kwargs):
-    return get_gisce_meme_url(kwargs)
 
 
 # Def Handler
@@ -53,7 +48,7 @@ def get_gisce_meme(**kwargs):
 @remove_command_message
 def cb_gisce_meme_handler(update, context):
     logger.info("Handling meme")
-    update.message.reply_photo(get_gisce_meme(id=None, tags=None), quote=False)
+    update.message.reply_photo(get_gisce_meme_url(id=None, tags=None), quote=False)
 
 
 gisce_meme_handler = CommandHandler("gisce_meme", cb_gisce_meme_handler)


### PR DESCRIPTION
## Case

Adds a new command to the bot:
  - `/gisce_meme`

This command makes a request to `https://bcclean.tk/ImageServer/api/` in order to get a random gisce meme.

`ImageServer` is a very simple images server build with flask that can return images by id, random images or random images with specific tags (see https://github.com/bcedu/ImageServer).

The api is protected with basic authentication, so you must add to the conf file:

- `image_server_user`
- `image_server_password`

### Future improvements

By now it only supports getting random memes, but the api suports get random memes related to a tag using `random_image/<tag>`. I have not integrated this call to the bot because I still have not added the tags to the memes of ImageServer.

## Observations


