### PR TITLE
Fix find for macOS

### DIFF
--- a/checks.sh
+++ b/checks.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-pyfiles=$(find -type f | grep .py | grep -v 'pycache' | grep -v 'build' | grep -v 'mypy')
+pyfiles=$(find . -type f | grep .py | grep -v 'pycache' | grep -v 'build' | grep -v 'mypy')
 
 if [ "$pyfiles" ]
 then


### PR DESCRIPTION
Fix `find` command executed in the `checks.sh` for macOS.